### PR TITLE
fix: auto assign reviews workflow has no permissions

### DIFF
--- a/.github/auto_request_review.yml
+++ b/.github/auto_request_review.yml
@@ -1,6 +1,6 @@
 reviewers:
   defaults:
-    - 'nkwangleiGIT'
+#     - 'nkwangleiGIT'
     - 0xff-dev
     - Abirdcfly
 
@@ -15,7 +15,7 @@ reviewers:
       - Abirdcfly
     tests:
       - Abirdcfly
-      - 'nkwangleiGIT'
+#       - 'nkwangleiGIT'
 
 files:
   '.github/**':
@@ -47,4 +47,4 @@ options:
   enable_group_assignment: true
 
   # Do not set this option if you'd like to assign all matching reviewers.
-  number_of_reviewers: 3
+  # number_of_reviewers: 3

--- a/.github/workflows/auto_assign_reviewers.yml
+++ b/.github/workflows/auto_assign_reviewers.yml
@@ -1,17 +1,19 @@
 name: Auto Request Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review, reopened]
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   auto-request-review:
     name: Auto Request Review
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
       - name: Request review based on files changes and/or groups the author belongs to
-        uses: necojackarc/auto-request-review@v0.8.0
+        uses: necojackarc/auto-request-review@v0.7.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:


1. If this is your first time, please read our contributor guidelines: https://github.com/kube-arbiter/arbiter/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
