### PR TITLE
cleanup: use tag dev for plugin in tests

### DIFF
--- a/tests/install-infra.sh
+++ b/tests/install-infra.sh
@@ -49,9 +49,11 @@ function install_crd {
 
 	kubectl -n ${ARBITER_NS} apply -f $ROOT/manifests/install/observer/observer-rbac.yaml
 	# install observer metric-server
-	cat $ROOT/manifests/install/observer/observer-metric-server.yaml | sed -e 's/kubearbiter\/observer:.*/localhost:5001\/arbiter.k8s.com.cn\/observer:e2e/g' | kubectl -n ${ARBITER_NS} apply -f -
+	# use kubearbiter/observer-metric-server:dev for e2e test
+	cat $ROOT/manifests/install/observer/observer-metric-server.yaml | sed -e 's/kubearbiter\/observer:.*/localhost:5001\/arbiter.k8s.com.cn\/observer:e2e/g' -e 's/kubearbiter\/observer-metric-server:.*/kubearbiter\/observer-metric-server:dev/g' | kubectl -n ${ARBITER_NS} apply -f -
 	# install observer prometheus
-	cat $ROOT/manifests/install/observer/observer-prometheus.yaml | sed -e 's/kubearbiter\/observer:.*/localhost:5001\/arbiter.k8s.com.cn\/observer:e2e/g' | kubectl -n ${ARBITER_NS} apply -f -
+	# use kubearbiter/observer-promtheus:dev for e2e test
+	cat $ROOT/manifests/install/observer/observer-prometheus.yaml | sed -e 's/kubearbiter\/observer:.*/localhost:5001\/arbiter.k8s.com.cn\/observer:e2e/g' -e 's/kubearbiter\/observer-prometheus:.*/kubearbiter\/observer-prometheus:dev/g' | kubectl -n ${ARBITER_NS} apply -f -
 
 	kubectl wait deployment --timeout=${TIMEOUT} -n ${ARBITER_NS} observer-metric-server --for condition=Available=True
 	echo "observer-metric-server install finish..."
@@ -60,8 +62,8 @@ function install_crd {
 	# install executor rbac
 	kubectl -n ${ARBITER_NS} apply -f $ROOT/manifests/install/executor/executor-rbac.yaml
 	# install executor
-	# use kubearbiter/executor-resource-tagger:e2e for e2e test
-	cat $ROOT/manifests/install/executor/executor-resource-tagger.yaml | sed -e 's/kubearbiter\/executor:.*/localhost:5001\/arbiter.k8s.com.cn\/executor:e2e/g' -e 's/kubearbiter\/executor-resource-tagger:.*/kubearbiter\/executor-resource-tagger:e2e/g' | kubectl -n ${ARBITER_NS} apply -f -
+	# use kubearbiter/executor-resource-tagger:dev for e2e test
+	cat $ROOT/manifests/install/executor/executor-resource-tagger.yaml | sed -e 's/kubearbiter\/executor:.*/localhost:5001\/arbiter.k8s.com.cn\/executor:e2e/g' -e 's/kubearbiter\/executor-resource-tagger:.*/kubearbiter\/executor-resource-tagger:dev/g' | kubectl -n ${ARBITER_NS} apply -f -
 	kubectl wait deployment --timeout=${TIMEOUT} -n ${ARBITER_NS} executor-resource-tagger --for condition=Available=True
 	echo "executor install finish..."
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:


1. If this is your first time, please read our contributor guidelines: https://github.com/kube-arbiter/arbiter/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Because https://github.com/kube-arbiter/arbiter-plugins/pull/5 was merged, once the pull request from code repository https://github.com/kube-arbiter/arbiter-plugins is merged, the `push` workflow will be triggered automatically and the image will be automatically built, tagged as `dev` and pushed to dockerhub automatically, so we can get rid of the problem of manually building and pushing the image.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
