### PR TITLE
fix: drop non-inherited context in executor

### DIFF
--- a/pkg/executor/observabilityindicant_controller.go
+++ b/pkg/executor/observabilityindicant_controller.go
@@ -52,7 +52,7 @@ func (r *ObservabilityIndicantReconciler) Reconcile(ctx context.Context, req ctr
 	logger := log.FromContext(ctx)
 
 	instance := &arbiterv1alpha1.ObservabilityIndicant{}
-	err := r.Client.Get(context.TODO(), req.NamespacedName, instance)
+	err := r.Client.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return ctrl.Result{}, nil
@@ -70,7 +70,7 @@ func (r *ObservabilityIndicantReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	oap := &arbiterv1alpha1.ObservabilityActionPolicy{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Client.Get(ctx, types.NamespacedName{
 		Namespace: instance.Namespace,
 		Name:      policyName,
 	}, oap)
@@ -88,7 +88,7 @@ func (r *ObservabilityIndicantReconciler) Reconcile(ctx context.Context, req ctr
 	}
 	if oap.Annotations["obi-resource-version"] != instance.ObjectMeta.GetResourceVersion() {
 		oap.Annotations["obi-resource-version"] = instance.ObjectMeta.GetResourceVersion()
-		if err := r.Client.Update(context.Background(), oap); err != nil {
+		if err := r.Client.Update(ctx, oap); err != nil {
 			logger.Error(err, "update ObservabilityActionPolicy error")
 		}
 		logger.Info("obi-resource-version updated for observability-action-policy: ", instance.Namespace+"-"+policyName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:


1. If this is your first time, please read our contributor guidelines: https://github.com/kube-arbiter/arbiter/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When a function uses a non-inherited context, it will result in a broken call link.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
