### PR TITLE
Support to get general metrics that does not depend on pod/node resource

### DIFF
--- a/cmd/observer/main.go
+++ b/cmd/observer/main.go
@@ -116,7 +116,10 @@ func main() {
 	if err != nil {
 		klog.Fatalf("%s dial %s error: %s", utils.ErrorLogPrefix, *endpoint, err.Error())
 	}
-
+	fetcher, err := fetch.NewFetcher(conn, time.Duration(*fetchTimeout*int(time.Second)))
+	if err != nil {
+		klog.Fatalf("%s dial %s error: %s", utils.ErrorLogPrefix, *endpoint, err.Error())
+	}
 	c := controller.NewController(
 		*namespace,
 		kubeClient,
@@ -124,7 +127,7 @@ func main() {
 		obiClient,
 		kubeInformerFactory.Core().V1().Pods(),
 		obiInformerFactory.Arbiter().V1alpha1().ObservabilityIndicants(),
-		fetch.NewFetcher(conn, time.Duration(*fetchTimeout*int(time.Second))))
+		fetcher)
 
 	kubeInformerFactory.Start(stopCh)
 	obiInformerFactory.Start(stopCh)

--- a/manifests/crds/arbiter.k8s.com.cn_observabilityindicants.yaml
+++ b/manifests/crds/arbiter.k8s.com.cn_observabilityindicants.yaml
@@ -47,7 +47,7 @@ spec:
                     type: integer
                   metricIntervalSeconds:
                     format: int64
-                    minimum: 30
+                    minimum: 5
                     type: integer
                   metrics:
                     additionalProperties:

--- a/manifests/example/observer/metric/metric-server-node-cpu.yaml
+++ b/manifests/example/observer/metric/metric-server-node-cpu.yaml
@@ -5,7 +5,8 @@ metadata:
 spec:
   metric:
     historyLimit: 1
-    metricIntervalSeconds: 30
+    # metric-server collect metrics every 15 seconds
+    metricIntervalSeconds: 15
     metrics:
       cpu:
         aggregations:

--- a/manifests/example/observer/metric/metric-server-node-mem.yaml
+++ b/manifests/example/observer/metric/metric-server-node-mem.yaml
@@ -5,7 +5,8 @@ metadata:
 spec:
   metric:
     historyLimit: 1
-    metricIntervalSeconds: 30
+    # metric-server collect metrics every 15 seconds
+    metricIntervalSeconds: 15
     metrics:
       memory:
         aggregations:

--- a/manifests/example/observer/metric/metric-server-pod-cpu.yaml
+++ b/manifests/example/observer/metric/metric-server-pod-cpu.yaml
@@ -5,7 +5,8 @@ metadata:
 spec:
   metric:
     historyLimit: 1
-    metricIntervalSeconds: 30
+     # metric-server collect metrics every 15 seconds
+    metricIntervalSeconds: 15
     metrics:
       cpu:
         aggregations:

--- a/manifests/example/observer/metric/metric-server-pod-mem.yaml
+++ b/manifests/example/observer/metric/metric-server-pod-mem.yaml
@@ -5,7 +5,8 @@ metadata:
 spec:
   metric:
     historyLimit: 1
-    metricIntervalSeconds: 30
+    # metric-server collect metrics every 15 seconds
+    metricIntervalSeconds: 15
     metrics:
       memory:
         aggregations:

--- a/manifests/example/observer/prometheus/prometheus-node-cpu.yaml
+++ b/manifests/example/observer/prometheus/prometheus-node-cpu.yaml
@@ -10,7 +10,7 @@ spec:
       cpu:
         aggregations: [ ]
         description: cpu
-        query: (sum(count(node_cpu_seconds_total{mode="idle",node="{{.metadata.name}}"}) by (mode, cpu)) - sum(irate(node_cpu_seconds_total{mode="idle",node="{{.metadata.name}}"}[5m])))*1000
+        query: (sum(count(node_cpu_seconds_total{mode="idle",instance="{{.metadata.name}}"}) by (mode, cpu)) - sum(irate(node_cpu_seconds_total{mode="idle",instance="{{.metadata.name}}"}[5m])))*1000
         unit: 'm'
     timeRangeSeconds: 3600
   source: prometheus

--- a/manifests/example/observer/prometheus/prometheus-node-mem.yaml
+++ b/manifests/example/observer/prometheus/prometheus-node-mem.yaml
@@ -10,7 +10,7 @@ spec:
       memory:
         aggregations: []
         description: memory
-        query: sum(node_memory_MemTotal_bytes{node="{{.metadata.name}}"} - node_memory_MemAvailable_bytes{node="{{.metadata.name}}"})
+        query: sum(node_memory_MemTotal_bytes{instance="{{.metadata.name}}"} - node_memory_MemAvailable_bytes{instance="{{.metadata.name}}"})
         unit: byte
     timeRangeSeconds: 3600
   source: prometheus

--- a/pkg/apis/v1alpha1/observer_types.go
+++ b/pkg/apis/v1alpha1/observer_types.go
@@ -95,7 +95,7 @@ type ObservabilityIndicantSpecMetric struct {
 	Metrics          map[string]ObservabilityIndicantSpecMetricAbility `json:"metrics"`
 	TimeRangeSeconds int64                                             `json:"timeRangeSeconds"`
 
-	// +kubebuilder:validation:Minimum=30
+	// +kubebuilder:validation:Minimum=5
 	MetricIntervalSeconds int64 `json:"metricIntervalSeconds"`
 
 	// +kubebuilder:validation:Minimum=1

--- a/pkg/fetch/fetch.go
+++ b/pkg/fetch/fetch.go
@@ -33,11 +33,12 @@ import (
 type FetchErrorType uint8
 
 const (
-	FetchOK        FetchErrorType = 0
-	FetchCtxDone   FetchErrorType = 1
-	FetchTimeOut   FetchErrorType = 2
-	FetchRPC       FetchErrorType = 3
-	FetchDoNothing FetchErrorType = 4
+	FetchOK                  FetchErrorType = 0
+	FetchCtxDone             FetchErrorType = 1
+	FetchTimeOut             FetchErrorType = 2
+	FetchRPC                 FetchErrorType = 3
+	FetchDoNothing           FetchErrorType = 4
+	MaximumConnectRetryCount                = 10
 )
 
 type Resp struct {
@@ -84,23 +85,35 @@ type fetcher struct {
 // verify fetcher impl Fetcher
 var _ Fetcher = &fetcher{}
 
-func NewFetcher(conn *grpc.ClientConn, fetchTimeout time.Duration) Fetcher {
+func NewFetcher(conn *grpc.ClientConn, fetchTimeout time.Duration) (Fetcher, error) {
 	f := &fetcher{rpcCli: obi.NewServerClient(conn), timeout: fetchTimeout}
-	capabilitiers, err := f.rpcCli.PluginCapabilities(context.Background(), &obi.PluginCapabilitiesRequest{})
-	if err != nil {
-		klog.Infof("NewFetcher: try get capabilities error: %s\n", err)
-		return f
+	// try to connect to observer plugin
+	retryCount := 1
+	var capabilitiers *obi.PluginCapabilitiesResponse
+	var err error
+	for {
+		capabilitiers, err = f.rpcCli.PluginCapabilities(context.Background(), &obi.PluginCapabilitiesRequest{})
+		if err != nil {
+			klog.Errorf("NewFetcher: try to get capabilities error: %s\n", err)
+			time.Sleep(5 * time.Second)
+			retryCount++
+			if retryCount >= MaximumConnectRetryCount {
+				return f, err
+			}
+		} else {
+			break
+		}
 	}
 
 	f.capabilities = capabilitiers.MetricInfo
 	r, err := f.rpcCli.GetPluginName(context.Background(), &obi.GetPluginNameRequest{})
 	if err != nil {
-		klog.Infof("NewFetcher: try get plugin name error: %s\n", err)
-		return f
+		klog.Infof("NewFetcher: try to get plugin name error: %s\n", err)
+		return f, err
 	}
 	klog.Infof("NewFetcher plugin name: %s\n", r.Name)
 	f.outPluginName = r.Name
-	return f
+	return f, nil
 }
 
 func (f *fetcher) Health() bool {
@@ -113,10 +126,6 @@ func (f *fetcher) GetPluginName() string {
 
 func (f *fetcher) Fetch(ctx context.Context, req *obi.GetMetricsRequest) (*v1alpha1.ObservabilityIndicantStatusMetricInfo, FetchErrorType, error) {
 	method := "fetcher.Fetch"
-
-	if len(req.ResourceNames) == 0 {
-		return nil, FetchDoNothing, nil
-	}
 
 	klog.V(5).Infof("Starting to fetch metrics for resource: %s\n", req.ResourceNames)
 	fetchResult := make(chan error)

--- a/pkg/fetch/fetch.go
+++ b/pkg/fetch/fetch.go
@@ -97,7 +97,7 @@ func NewFetcher(conn *grpc.ClientConn, fetchTimeout time.Duration) (Fetcher, err
 			klog.Errorf("NewFetcher: try to get capabilities error: %s\n", err)
 			time.Sleep(5 * time.Second)
 			retryCount++
-			if retryCount >= MaximumConnectRetryCount {
+			if retryCount > MaximumConnectRetryCount {
 				return f, err
 			}
 		} else {


### PR DESCRIPTION
1. Remove the socket file during server shutdown
2. Support to get general metrics that does not depend on pod/node with empty/other kind in the OBI

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
