### PR TITLE
fix: check obi data in e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -91,10 +91,10 @@ jobs:
       - name: E2E Test
         timeout-minutes: 60
         run: |
-          bash tests/prepare-k8s.sh
-          bash tests/install-infra.sh
+          bash -x tests/prepare-k8s.sh
+          bash -x tests/install-infra.sh
           cd tests/e2e
-          ginkgo -v
+          ginkgo -vv
       - name: Export logs
         if: failure()
         run: bash tests/export-logs.sh

--- a/manifests/example/observer/prometheus/prometheus-cluster-schedulable-cpu.yaml
+++ b/manifests/example/observer/prometheus/prometheus-cluster-schedulable-cpu.yaml
@@ -13,9 +13,9 @@ spec:
       cpu:
         aggregations: [ ]
         description: cpu
-        query: sum(kube_node_status_allocatable_cpu_cores)
-          - sum(sum by (node)(kube_node_status_allocatable_cpu_cores) / (group by (node)(kube_node_spec_taint{name="kube-state-metrics",effect="NoSchedule"})))
-          - sum(sum by (node) (kube_pod_container_resource_requests_cpu_cores)/ group by (node) (kube_node_spec_unschedulable{} == 0))
+        query: sum(kube_node_status_allocatable{resource="cpu"})
+          - (sum(sum by (node)(kube_node_status_allocatable{resource="cpu"}) / (group by (node)(kube_node_spec_taint{name="kube-state-metrics",effect="NoSchedule"}))) or on () vector(0))
+          - sum(sum by (node) (kube_pod_container_resource_requests{resource="cpu"})/ group by (node) (kube_node_spec_unschedulable == 0))
         unit: 'm'
     timeRangeSeconds: 3600
   source: prometheus

--- a/manifests/example/observer/prometheus/prometheus-max-available-cpu.yaml
+++ b/manifests/example/observer/prometheus/prometheus-max-available-cpu.yaml
@@ -13,8 +13,8 @@ spec:
       cpu:
         aggregations: ["max"]
         description: cpu
-        query: max(sum by (node) (kube_node_status_allocatable_cpu_cores)
-          - sum by (node) (kube_pod_container_resource_requests_cpu_cores) / group by (node) (kube_node_spec_unschedulable{} == 0))
+        query: max(sum by (node) (kube_node_status_allocatable{resource="cpu"})
+          - sum by (node) (kube_pod_container_resource_requests{resource="cpu"}) / group by (node) (kube_node_spec_unschedulable == 0))
         unit: 'm'
     timeRangeSeconds: 3600
   source: prometheus

--- a/manifests/example/observer/prometheus/prometheus-node-cpu.yaml
+++ b/manifests/example/observer/prometheus/prometheus-node-cpu.yaml
@@ -10,7 +10,7 @@ spec:
       cpu:
         aggregations: [ ]
         description: cpu
-        query: (sum(count(node_cpu_seconds_total{mode="idle",instance="{{.metadata.name}}"}) by (mode, cpu)) - sum(irate(node_cpu_seconds_total{mode="idle",instance="{{.metadata.name}}"}[5m])))*1000
+        query: (sum(count(node_cpu_seconds_total{mode="idle", node="{{.metadata.name}}"}) by (mode, cpu)) - sum(irate(node_cpu_seconds_total{mode="idle", node="{{.metadata.name}}"}[5m])))*1000
         unit: 'm'
     timeRangeSeconds: 3600
   source: prometheus

--- a/manifests/example/observer/prometheus/prometheus-node-mem.yaml
+++ b/manifests/example/observer/prometheus/prometheus-node-mem.yaml
@@ -10,7 +10,7 @@ spec:
       memory:
         aggregations: []
         description: memory
-        query: sum(node_memory_MemTotal_bytes{instance="{{.metadata.name}}"} - node_memory_MemAvailable_bytes{instance="{{.metadata.name}}"})
+        query: sum(node_memory_MemTotal_bytes{node="{{.metadata.name}}"} - node_memory_MemAvailable_bytes{node="{{.metadata.name}}"})
         unit: byte
     timeRangeSeconds: 3600
   source: prometheus

--- a/tests/prepare-k8s.sh
+++ b/tests/prepare-k8s.sh
@@ -180,8 +180,8 @@ function install_scheduler_crd {
 }
 
 function remove_master_taint {
-	kubectl taint nodes arbiter-e2e-control-plane node-role.kubernetes.io/master- || echo 0
-	kubectl taint nodes arbiter-e2e-control-plane node-role.kubernetes.io/control-plane- || echo 0
+	kubectl taint nodes arbiter-e2e-control-plane node-role.kubernetes.io/master- 2>/dev/null || true
+	kubectl taint nodes arbiter-e2e-control-plane node-role.kubernetes.io/control-plane- 2>/dev/null || true
 }
 
 # main


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:


1. If this is your first time, please read our contributor guidelines: https://github.com/kube-arbiter/arbiter/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
1. metrics like `kube_node_status_allocatable_cpu_cores` and `kube_node_status_allocatable_cpu_cores` are marked as DEPRECATED.
2. metrics like `kube_node_spec_taint` will has no data when there is no taint in cluster.
3. The value (`.status.metrics.*[*].records.*.value`) is not a number and cant be summed does not means does not mean that it is wrong, perhaps the value is original raw data from prometheus.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #40 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
