### PR TITLE
feat: github action auto use ginkgo version in go.mod

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -72,19 +72,25 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'
-      - name: Install ginkgo v2.4.0
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.4.0
-# Kind 0.15.0 has preinstalled in github action
-# see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#preinstalled-software for more info
-#      - name: Install kind v0.15.0
-#        run: go install sigs.k8s.io/kind@v0.15.0
+      - name: Install ginkgo
+        run: |
+          version=$(cat go.mod| grep "ginkgo/v2" | awk '{print $2}')
+          go install -v github.com/onsi/ginkgo/v2/ginkgo@$version
+# Github action will pre-install close to the latest version of Kind,
+# but in our tests, to upgrade the kind version, it is best to verify that the old kubernetes node image is available
+# in the new version of Kind, and it is best to use the updated kubernetes node image provided by the new version of kind.
+# see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#preinstalled-software
+# for more info.
+      - name: Install kind v0.15.0
+        run: go install sigs.k8s.io/kind@v0.15.0
       - name: Install kubectl
         run: |
           curl -LO https://storage.googleapis.com/kubernetes-release/release/${{ matrix.k8s-version }}/bin/linux/amd64/kubectl
           chmod +x ./kubectl
           sudo mv ./kubectl /usr/local/bin/kubectl
-# Helm 3.9.4 has preinstalled in github action
-# see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#preinstalled-software for more info
+# Github action will be pre-installed with the latest version of Helm, our test does not limit the version of Helm.
+# see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#preinstalled-software
+# for more info.
 #      - name: Install helm
 #        run: |
 #          curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:


1. If this is your first time, please read our contributor guidelines: https://github.com/kube-arbiter/arbiter/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Let github action automatically install the ginkgo version specified in go.mod, so that @dependabot can automatically upgrade the ginkgo version without modifying github action script file.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
