### PR TITLE
fix webhook e2e test in 1.18

### DIFF
--- a/tests/e2e/webhook_test.go
+++ b/tests/e2e/webhook_test.go
@@ -18,6 +18,8 @@ package e2e_test
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -31,10 +33,15 @@ var _ = Describe("webhook", Label("webhook"), func() {
 			Expect(countChecker(testpodResourceCommand(), &output)).Error().Should(Succeed(), func() {
 				fmt.Println("check the resource of pod successfully")
 			})
-
-			Expect(output).To(Equal(`{"cpu":"50m","memory":"629145Ki"}`), func() string {
-				return output
-			})
+			if version := os.Getenv("K8S_VERSION"); strings.HasPrefix(version, "v1.18") {
+				Expect(output).To(Equal(`map[cpu:50m memory:629145Ki]`), func() string {
+					return output
+				})
+			} else {
+				Expect(output).To(Equal(`{"cpu":"50m","memory":"629145Ki"}`), func() string {
+					return output
+				})
+			}
 		})
 	})
 })


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

fix #84

<!--  Thanks for sending a pull request!  Here are some tips for you:


1. If this is your first time, please read our contributor guidelines: https://github.com/kube-arbiter/arbiter/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #84

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
